### PR TITLE
fix bug in min-cut caused by mutation from sort

### DIFF
--- a/graph.lisp
+++ b/graph.lisp
@@ -1275,7 +1275,7 @@ through to guide the A* search used in `shortest-path'.")
                 (rest (remove (car a) (nodes g))))
            (loop :while rest :do
               ;; grow A by adding the node most tightly connected to A
-              (let ((new (car (sort rest #'> :key {connection-weight a}))))
+              (let ((new (extremum rest #'> :key {connection-weight a})))
                 (setf rest (remove new rest))
                 (push new a)))
            ;; store the cut-of-phase


### PR DESCRIPTION
fixes https://github.com/eschulte/graph/issues/14
by using extremum instead of `(car (sort ...` which causes a bug because of sort's mutation side effect, it should also be slightly more efficient as it just gets the min instead of sorting the whole list